### PR TITLE
Fix compile error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eelgame"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 crossterm = "0.27"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use crossterm::{
     execute,
     style::{Color, SetForegroundColor},
     terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
+    Result as CrosstermResult,
 };
 use rand::{thread_rng, Rng};
 use std::collections::VecDeque;
@@ -86,7 +87,7 @@ impl Game {
     }
 }
 
-fn draw(game: &Game, stdout: &mut std::io::Stdout) -> crossterm::Result<()> {
+fn draw(game: &Game, stdout: &mut std::io::Stdout) -> CrosstermResult<()> {
     execute!(stdout, cursor::MoveTo(0, 0))?;
     for y in 0..HEIGHT {
         for x in 0..WIDTH {
@@ -105,7 +106,7 @@ fn draw(game: &Game, stdout: &mut std::io::Stdout) -> crossterm::Result<()> {
     stdout.flush()
 }
 
-fn main() -> crossterm::Result<()> {
+fn main() -> CrosstermResult<()> {
     let mut stdout = stdout();
     terminal::enable_raw_mode()?;
     execute!(


### PR DESCRIPTION
## Summary
- fix package edition from 2024 to 2021
- use `CrosstermResult` alias for functions

## Testing
- `cargo check` *(fails: could not download crates due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683a121b356883319df8e1d3dca7ac2b